### PR TITLE
Angular momentum ints and magnetic dipoles

### DIFF
--- a/pycc/data/molecules.py
+++ b/pycc/data/molecules.py
@@ -209,6 +209,15 @@ symmetry c1
 """
 
 # Chiral molecules
+# H2 dimer
+h2_2 = """
+H
+H 1 0.75
+H 2 1.5 1 90.0
+H 3 0.75 2 90.0 1 60.0
+symmetry c1
+"""
+
 # (S)-1,3-dimethylallene
 sdma = """
 C  0.000000  0.000000  0.414669
@@ -272,6 +281,7 @@ moldict["(H2O)_6"] = h2o_6
 moldict["(H2O)_7"] = h2o_7
 moldict["uracil"] = uracil
 moldict["benzene"] = benzene
+moldict["(H2)_2"] = h2_2
 moldict["(S)-dimethylallene"] = sdma
 moldict["(S)-2-chloropropionitrile"] = s2cpn
 moldict["(R)-methylthiirane"] = rmt

--- a/pycc/rtcc.py
+++ b/pycc/rtcc.py
@@ -62,10 +62,10 @@ class rtcc(object):
         self.mu_tot = sum(self.mu)/np.sqrt(3.0)  # isotropic field
 
         if magnetic:
-            m_ints = -0.5 * mints.ao_angular_momentum()
+            m_ints = mints.ao_angular_momentum()
             self.m = []
             for axis in range(3):
-                self.m.append(C.T @ np.asarray(m_ints[axis]) @ C)
+                self.m.append(C.T @ (np.asarray(m_ints[axis])*-0.5) @ C)
 
     def f(self, t, y):
         """
@@ -140,7 +140,7 @@ class rtcc(object):
 
         return t1, t2, l1, l2
 
-    def dipole(self, t1, t2, l1, l2, magnetic = False):
+    def dipole(self, t1, t2, l1, l2, withref = True, magnetic = False):
         """
         Parameters
         ----------
@@ -152,7 +152,7 @@ class rtcc(object):
         x, y, z : complex128
             Cartesian components of the dipole moment
         """
-        opdm = self.ccdensity.compute_onepdm(t1, t2, l1, l2, withref=True)
+        opdm = self.ccdensity.compute_onepdm(t1, t2, l1, l2, withref=withref)
         if magnetic:
             ints = self.m
         else:

--- a/pycc/rtcc.py
+++ b/pycc/rtcc.py
@@ -28,6 +28,8 @@ class rtcc(object):
         the dipole integrals for each Cartesian direction
     mu_tot: NumPy arrays
         1/sqrt(3) * sum of dipole integrals (for isotropic field)
+    m: list of NumPy arrays
+        the magnetic dipole integrals for each Cartesian direction (only if dipole = True)
 
     Methods
     -------
@@ -38,13 +40,13 @@ class rtcc(object):
     extract_amps():
         Separate a flattened array of cluster amplitudes into the t1, t2, l1, and l2 components
     dipole()
-        Compute the electronic dipole moment for a given time t
+        Compute the electronic or magnetic dipole moment for a given time t
     energy()
         Compute the CC correlation energy for a given time t
     lagrangian()
         Compute the CC Lagrangian energy for a given time t
     """
-    def __init__(self, ccwfn, cclambda, ccdensity, V):
+    def __init__(self, ccwfn, cclambda, ccdensity, V, magnetic = False):
         self.ccwfn = ccwfn
         self.cclambda = cclambda
         self.ccdensity = ccdensity
@@ -58,6 +60,12 @@ class rtcc(object):
         for axis in range(3):
             self.mu.append(C.T @ np.asarray(dipole_ints[axis]) @ C)
         self.mu_tot = sum(self.mu)/np.sqrt(3.0)  # isotropic field
+
+        if magnetic:
+            m_ints = mints.ao_angular_momentum()
+            self.m = []
+            for axis in range(3):
+                self.m.append(C.T @ np.asarray(m_ints[axis]) @ C)
 
     def f(self, t, y):
         """
@@ -132,7 +140,7 @@ class rtcc(object):
 
         return t1, t2, l1, l2
 
-    def dipole(self, t1, t2, l1, l2):
+    def dipole(self, t1, t2, l1, l2, magnetic = False):
         """
         Parameters
         ----------
@@ -141,14 +149,18 @@ class rtcc(object):
 
         Returns
         -------
-        mu_x, mu_y, mu_z : complex128
+        x, y, z : complex128
             Cartesian components of the dipole moment
         """
         opdm = self.ccdensity.compute_onepdm(t1, t2, l1, l2, withref=True)
-        mu_x = self.mu[0].flatten().dot(opdm.flatten())
-        mu_y = self.mu[1].flatten().dot(opdm.flatten())
-        mu_z = self.mu[2].flatten().dot(opdm.flatten())
-        return mu_x, mu_y, mu_z
+        if magnetic:
+            ints = self.m
+        else:
+            ints = self.mu
+        x = ints[0].flatten().dot(opdm.flatten())
+        y = ints[1].flatten().dot(opdm.flatten())
+        z = ints[2].flatten().dot(opdm.flatten())
+        return x, y, z
 
     def energy(self, t, t1, t2, l1, l2):
         """

--- a/pycc/rtcc.py
+++ b/pycc/rtcc.py
@@ -62,7 +62,7 @@ class rtcc(object):
         self.mu_tot = sum(self.mu)/np.sqrt(3.0)  # isotropic field
 
         if magnetic:
-            m_ints = mints.ao_angular_momentum()
+            m_ints = -0.5 * mints.ao_angular_momentum()
             self.m = []
             for axis in range(3):
                 self.m.append(C.T @ np.asarray(m_ints[axis]) @ C)

--- a/pycc/rtcc.py
+++ b/pycc/rtcc.py
@@ -146,6 +146,10 @@ class rtcc(object):
         ----------
         t1, t2, l1, l2 : NumPy arrays
             current cluster amplitudes
+        withref        : Bool (default = True)
+            include reference contribution to the OPDM
+        magnetic       : Bool (default = False)
+            compute magnetic dipole rather than electric
 
         Returns
         -------

--- a/pycc/tests/test_007_dipole.py
+++ b/pycc/tests/test_007_dipole.py
@@ -1,0 +1,57 @@
+"""
+Test CCSD electric and magnetic dipole on H2 dimer.
+"""
+
+# Import package, test suite, and other packages as needed
+import psi4
+import pycc
+import pytest
+from ..data.molecules import *
+
+def test_dipole_h2_2_cc_pvdz():
+    """He cc-pVDZ"""
+    psi4.set_memory('2 GiB')
+    psi4.core.set_output_file('output.dat', False)
+    psi4.set_options({'basis': 'cc-pVDZ',
+                      'scf_type': 'pk',
+                      'mp2_type': 'conv',
+                      'freeze_core': 'false',
+                      'e_convergence': 1e-13,
+                      'd_convergence': 1e-13,
+                      'r_convergence': 1e-13,
+                      'diis': 1})
+    mol = psi4.geometry(moldict["(H2)_2"])
+    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
+
+    e_conv = 1e-13
+    r_conv = 1e-13
+
+    cc = pycc.ccenergy(rhf_wfn)
+    ecc = cc.solve_ccsd(e_conv, r_conv)
+
+    hbar = pycc.cchbar(cc)
+
+    cclambda = pycc.cclambda(cc, hbar)
+    lecc = cclambda.solve_lambda(e_conv, r_conv)
+
+    ccdensity = pycc.ccdensity(cc, cclambda)
+
+    # no laser
+    rtcc = pycc.rtcc(cc, cclambda, ccdensity, None, magnetic = True)
+    y0 = rtcc.collect_amps(cc.t1, cc.t2, cclambda.l1, cclambda.l2).astype('complex128')
+    t1, t2, l1, l2 = rtcc.extract_amps(y0)
+
+    ref = [0, 0, 0.005371586416860086] # au
+    mu_x, mu_y, mu_z = rtcc.dipole(t1, t2, l1, l2)
+    opdm = rtcc.ccdensity.compute_onepdm(t1, t2, l1, l2, withref = True)
+
+    assert (abs(ref[0] - mu_x) < 1E-10)
+    assert (abs(ref[1] - mu_y) < 1E-10)
+    assert (abs(ref[2] - mu_z) < 1E-10)
+
+    ref = [0, 0, -2.3037968376087573E-5]
+    m_x, m_y, m_z = rtcc.dipole(t1, t2, l1, l2, magnetic = True)
+
+    assert (abs(ref[0] - m_x) < 1E-10)
+    assert (abs(ref[1] - m_y) < 1E-10)
+    assert (abs(ref[2] - m_z) < 1E-10)


### PR DESCRIPTION
## Description
Add optional for attaching angular momentum integrals and computing magnetic dipoles.

Also adds a new chiral test molecule (H2 dimer) and the option to compute dipoles with only the correlated OPDM.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Add angular momentum ints
  - [x] Add magnetic dipoles
  - [x] Add test case
  - [x] Docstrings

## Status
- [x] Ready to go